### PR TITLE
index.html: move license comment after head tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,14 @@
 <!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="description" content="A diff viewer.">
+        <title>webrev</title>
+        <link rel="stylesheet" href="style.css" />
+        <link rel="shortcut icon" type="image/x-icon" href="favicon.ico" />
+        <script src="webrev.js" type="text/javascript"></script>
+    </head>
 <!--
  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -21,16 +31,6 @@
  or visit www.oracle.com if you need additional information or have any
  questions.
  -->
-<html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <meta name="description" content="A diff viewer.">
-        <title>webrev</title>
-        <link rel="stylesheet" href="style.css" />
-        <link rel="shortcut icon" type="image/x-icon" href="favicon.ico" />
-        <script src="webrev.js" type="text/javascript"></script>
-    </head>
     <body>
     </body>
 </html>


### PR DESCRIPTION
Hi all,

please review this patch that moves the license comment in `index.html` to _after_ the `<head>` tag to allow browsers to see the `<meta>` tags within the first 1024 bytes.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/cr pull/9/head:pull/9` \
`$ git checkout pull/9`

Update a local copy of the PR: \
`$ git checkout pull/9` \
`$ git pull https://git.openjdk.java.net/cr pull/9/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9`

View PR using the GUI difftool: \
`$ git pr show -t 9`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/cr/pull/9.diff">https://git.openjdk.java.net/cr/pull/9.diff</a>

</details>
