### PR TITLE
index.html: remove indentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <meta name="description" content="A diff viewer.">
-        <title>webrev</title>
-        <link rel="stylesheet" href="style.css" />
-        <link rel="shortcut icon" type="image/x-icon" href="favicon.ico" />
-        <script src="webrev.js" type="text/javascript"></script>
-    </head>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="A diff viewer.">
+<title>webrev</title>
+<link rel="stylesheet" href="style.css" />
+<link rel="shortcut icon" type="image/x-icon" href="favicon.ico" />
+<script src="webrev.js" type="text/javascript"></script>
+</head>
 <!--
  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -31,6 +31,6 @@
  or visit www.oracle.com if you need additional information or have any
  questions.
  -->
-    <body>
-    </body>
+<body>
+</body>
 </html>


### PR DESCRIPTION
Hi all,

please review this small pull request that removes the indentation from `index.html`. This is preparation for inlining `style.css` and `webrev.js` into `index.html` (to reduce the number of network requests). When `style.css` and `webrev.js` is inlined then it is easier to read `index.html` without indentation.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/cr pull/11/head:pull/11` \
`$ git checkout pull/11`

Update a local copy of the PR: \
`$ git checkout pull/11` \
`$ git pull https://git.openjdk.java.net/cr pull/11/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11`

View PR using the GUI difftool: \
`$ git pr show -t 11`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/cr/pull/11.diff">https://git.openjdk.java.net/cr/pull/11.diff</a>

</details>
