### PR TITLE
988: Skara webrev is empty if patch has deleted files

### DIFF
--- a/index.html
+++ b/index.html
@@ -501,10 +501,7 @@ async function renderIndex(state) {
             patchFile.innerHTML = "Patch";
             code.append(patchFile, " ");
 
-            const rawFile = create("a");
-            rawFile.href = "https://raw.githubusercontent.com/" + metadata.head.repo.full_name + "/" + metadata.head.sha + "/" + file.filename;
-            rawFile.innerHTML = "Raw";
-            code.append(rawFile, " ");
+            code.append("--- ");
 
             p.append(code);
 
@@ -1521,7 +1518,9 @@ function removeContext(patch) {
             dstLines.push(line);
         } else if (line.startsWith("\\ No newline at end of file")) {
             continue;
-            } else {
+        } else if (line == "") {
+            continue;
+        } else {
             throw "Unexpected content on line " + i + ": '" + line + "'";
         }
     }
@@ -1620,9 +1619,6 @@ function fetchFileContent(state) {
 function fetchFileAtHead(state) {
     const index = state.index;
     const file = state.comparison.files[index];
-    if (file.status === "deleted") {
-        return;
-    }
 
     const raw_url = "https://raw.githubusercontent.com";
     const sha = state.metadata.head.sha;

--- a/index.html
+++ b/index.html
@@ -1518,7 +1518,7 @@ function removeContext(patch) {
             dstLines.push(line);
         } else if (line.startsWith("\\ No newline at end of file")) {
             continue;
-        } else if (line == "") {
+        } else if (line === "") {
             continue;
         } else {
             throw "Unexpected content on line " + i + ": '" + line + "'";
@@ -1619,6 +1619,9 @@ function fetchFileContent(state) {
 function fetchFileAtHead(state) {
     const index = state.index;
     const file = state.comparison.files[index];
+    if (file.status === "deleted") {
+        return Promise.resolve([]);
+    }
 
     const raw_url = "https://raw.githubusercontent.com";
     const sha = state.metadata.head.sha;


### PR DESCRIPTION
If a file in the patch has been deleted this causes a dereference of an undefined value. To fix this I removed the quick return in fetchFileContent so that this function always returns a value.

While verifying this, I also noted that the deleted file gets a Raw link which results in a 404. I think it should just not print the Raw link so I removed that too.

If a file has only been renamed, with no other changes, the patch will be an empty string. This upsets the hunk loop, so I added a case for handling this.

The resulting webrevs from the two reported patches look correct to me with these changes, but I would appreciate some more eyes on this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-988](https://bugs.openjdk.java.net/browse/SKARA-988): Skara webrev is empty if patch has deleted files


### Reviewers
 * [Robin Westberg](https://openjdk.java.net/census#rwestberg) (@rwestberg - **Reviewer**) ⚠️ Review applies to 239d79c29c0c214ca607bd05f4665873ff007274
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/cr pull/14/head:pull/14` \
`$ git checkout pull/14`

Update a local copy of the PR: \
`$ git checkout pull/14` \
`$ git pull https://git.openjdk.java.net/cr pull/14/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14`

View PR using the GUI difftool: \
`$ git pr show -t 14`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/cr/pull/14.diff">https://git.openjdk.java.net/cr/pull/14.diff</a>

</details>
