### PR TITLE
1006: The footer link of webrev.js is broken

### DIFF
--- a/index.html
+++ b/index.html
@@ -532,7 +532,7 @@ async function renderIndex(state) {
     footer.className = "version";
 
     const webrevLink = create("a");
-    webrevLink.href = "https://git.openjdk.java.net/cr/blob/master/webrev.js";
+    webrevLink.href = "https://git.openjdk.java.net/cr";
     webrevLink.innerHTML = "webrev.js";
     footer.append("This code review page was prepared using ", webrevLink, ".");
 


### PR DESCRIPTION
Hi all,

please review this patch that fixes the link to `webrev.js` in the index view.

Thanks,
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1006](https://bugs.openjdk.java.net/browse/SKARA-1006): The footer link of webrev.js is broken


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/cr pull/15/head:pull/15` \
`$ git checkout pull/15`

Update a local copy of the PR: \
`$ git checkout pull/15` \
`$ git pull https://git.openjdk.java.net/cr pull/15/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15`

View PR using the GUI difftool: \
`$ git pr show -t 15`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/cr/pull/15.diff">https://git.openjdk.java.net/cr/pull/15.diff</a>

</details>
