### PR TITLE
1015: Webrev can't handle changes with binary files

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,10 +227,14 @@ function render(state) {
     body().removeEventListener("keydown", framesOnKeyDown);
     body().style.margin = 0;
     if (state.view !== "index") {
-        if (state.head.content[state.index] === null || state.base.content[state.index] === null) {
-            const content = fetchFileContent(state);
-            state.head.content[state.index] = content.head;
-            state.base.content[state.index] = content.base;
+        if (state.comparison.files[state.index].binary === false) {
+            if (state.head.content[state.index] === null || state.base.content[state.index] === null) {
+                const content = fetchFileContent(state);
+                if (content != null) {
+                    state.head.content[state.index] = content.head;
+                    state.base.content[state.index] = content.base;
+                }
+            }
         }
     }
     if (state.view === "index") {
@@ -402,40 +406,50 @@ async function renderIndex(state) {
         const p = create("p");
         const code = create("code");
         if (file.status === "modified" || file.status === "copied" || file.status === "renamed") {
-            const cdiff = create("a");
-            cdiff.href = "#cdiff-" + i + "-" + filename;
-            cdiff.innerHTML = "Cdiffs";
-            code.append(cdiff, " ");
+            if (file.binary === true) {
+                code.append("------ ");
+                code.append("------ ");
+                code.append("------ ");
+                code.append("------ ");
+                code.append("--- ");
+                code.append("--- ");
+                code.append("----- ");
+            } else {
+                const cdiff = create("a");
+                cdiff.href = "#cdiff-" + i + "-" + filename;
+                cdiff.innerHTML = "Cdiffs";
+                code.append(cdiff, " ");
 
-            const udiff = create("a");
-            udiff.href = "#udiff-" + i + "-" + filename;
-            udiff.innerHTML = "Udiffs";
-            code.append(udiff, " ");
+                const udiff = create("a");
+                udiff.href = "#udiff-" + i + "-" + filename;
+                udiff.innerHTML = "Udiffs";
+                code.append(udiff, " ");
 
-            const sdiff = create("a");
-            sdiff.href = "#sdiff-" + i + "-" + filename;
-            sdiff.innerHTML = "Sdiffs";
-            code.append(sdiff, " ");
+                const sdiff = create("a");
+                sdiff.href = "#sdiff-" + i + "-" + filename;
+                sdiff.innerHTML = "Sdiffs";
+                code.append(sdiff, " ");
 
-            const frames = create("a");
-            frames.href = "#frames-" + i + "-" + filename;
-            frames.innerHTML = "Frames";
-            code.append(frames, " ");
+                const frames = create("a");
+                frames.href = "#frames-" + i + "-" + filename;
+                frames.innerHTML = "Frames";
+                code.append(frames, " ");
 
-            const oldFile = create("a");
-            oldFile.href = "#old-" + i + "-" + filename;
-            oldFile.innerHTML = "Old";
-            code.append(oldFile, " ");
+                const oldFile = create("a");
+                oldFile.href = "#old-" + i + "-" + filename;
+                oldFile.innerHTML = "Old";
+                code.append(oldFile, " ");
 
-            const newFile = create("a");
-            newFile.href = "#new-" + i + "-" + filename;
-            newFile.innerHTML = "New";
-            code.append(newFile, " ");
+                const newFile = create("a");
+                newFile.href = "#new-" + i + "-" + filename;
+                newFile.innerHTML = "New";
+                code.append(newFile, " ");
 
-            const patchFile = create("a");
-            patchFile.href = "#patch-" + i + "-" + filename;
-            patchFile.innerHTML = "Patch";
-            code.append(patchFile, " ");
+                const patchFile = create("a");
+                patchFile.href = "#patch-" + i + "-" + filename;
+                patchFile.innerHTML = "Patch";
+                code.append(patchFile, " ");
+            }
 
             const rawFile = create("a");
             rawFile.href = "https://raw.githubusercontent.com/" + metadata.head.repo.full_name + "/" + metadata.head.sha + "/" + file.filename;
@@ -461,15 +475,20 @@ async function renderIndex(state) {
             code.append("------ ");
             code.append("--- ");
 
-            const newFile = create("a");
-            newFile.href = "#new-" + i + "-" + filename;
-            newFile.innerHTML = "New";
-            code.append(newFile, " ");
+            if (file.binary === true) {
+                code.append("--- ");
+                code.append("----- ");
+            } else {
+                const newFile = create("a");
+                newFile.href = "#new-" + i + "-" + filename;
+                newFile.innerHTML = "New";
+                code.append(newFile, " ");
 
-            const patchFile = create("a");
-            patchFile.href = "#patch-" + i + "-" + filename;
-            patchFile.innerHTML = "Patch";
-            code.append(patchFile, " ");
+                const patchFile = create("a");
+                patchFile.href = "#patch-" + i + "-" + filename;
+                patchFile.innerHTML = "Patch";
+                code.append(patchFile, " ");
+            }
 
             const rawFile = create("a");
             rawFile.href = "https://raw.githubusercontent.com/" + metadata.head.repo.full_name + "/" + metadata.head.sha + "/" + file.filename;
@@ -489,19 +508,26 @@ async function renderIndex(state) {
             code.append("------ ");
             code.append("------ ");
 
-            const oldFile = create("a");
-            oldFile.href = "#old-" + i + "-" + filename;
-            oldFile.innerHTML = "Old";
-            code.append(oldFile, " ");
+            if (file.binary === true) {
+                code.append("--- ");
+                code.append("--- ");
+                code.append("----- ");
+                code.append("--- ");
+            } else {
+                const oldFile = create("a");
+                oldFile.href = "#old-" + i + "-" + filename;
+                oldFile.innerHTML = "Old";
+                code.append(oldFile, " ");
 
-            code.append("--- ");
+                code.append("--- ");
 
-            const patchFile = create("a");
-            patchFile.href = "#patch-" + i + "-" + filename;
-            patchFile.innerHTML = "Patch";
-            code.append(patchFile, " ");
+                const patchFile = create("a");
+                patchFile.href = "#patch-" + i + "-" + filename;
+                patchFile.innerHTML = "Patch";
+                code.append(patchFile, " ");
 
-            code.append("--- ");
+                code.append("--- ");
+            }
 
             p.append(code);
 
@@ -1477,57 +1503,59 @@ function addContext(hunks, n, baseContent, headContent) {
 
 function removeContext(patch) {
     const hunks = new Array();
-    let srcStart = 0;
-    let srcLines = new Array();
-    let dstStart = 0;
-    let dstLines = new Array();
-    let isBefore = true;
+    if (patch != null) {
+        let srcStart = 0;
+        let srcLines = new Array();
+        let dstStart = 0;
+        let dstLines = new Array();
+        let isBefore = true;
 
-    const lines = patch.split('\n');
-    const end = patch.endsWith('\n') ? lines.length - 1 : lines.length;
-    for (let i = 0; i < end; i++) {
-        const line = lines[i];
-        if (line.startsWith("@@")) {
-            if (srcLines.length > 0 || dstLines.length > 0) {
+        const lines = patch.split('\n');
+        const end = patch.endsWith('\n') ? lines.length - 1 : lines.length;
+        for (let i = 0; i < end; i++) {
+            const line = lines[i];
+            if (line.startsWith("@@")) {
+                if (srcLines.length > 0 || dstLines.length > 0) {
+                    hunks.push(new Hunk(srcStart, srcLines, dstStart, dstLines));
+                }
+
+                const parts = line.split(' ');
+                srcStart = Number(parseRange(parts[1]).start);
+                dstStart = Number(parseRange(parts[2]).start);
+                srcLines = new Array();
+                dstLines = new Array();
+            } else if (line.startsWith(' ') && !isBefore) {
+                while (i < lines.length && lines[i].startsWith(' ')) {
+                    i++;
+                }
                 hunks.push(new Hunk(srcStart, srcLines, dstStart, dstLines));
-            }
+                srcStart = srcStart + srcLines.length;
+                srcLines = new Array();
+                dstStart = dstStart + dstLines.length;
+                dstLines = new Array();
+            } else if (line.startsWith(' ') && isBefore) {
+                srcStart++;
+                dstStart++;
+            } else if (line.startsWith('-')) {
+                isBefore = false;
+                srcLines.push(line);
 
-            const parts = line.split(' ');
-            srcStart = Number(parseRange(parts[1]).start);
-            dstStart = Number(parseRange(parts[2]).start);
-            srcLines = new Array();
-            dstLines = new Array();
-        } else if (line.startsWith(' ') && !isBefore) {
-            while (i < lines.length && lines[i].startsWith(' ')) {
-                i++;
+            } else if (line.startsWith('+')) {
+                isBefore = false;
+                dstLines.push(line);
+            } else if (line.startsWith("\\ No newline at end of file")) {
+                continue;
+            } else if (line === "") {
+                continue;
+            } else {
+                throw "Unexpected content on line " + i + ": '" + line + "'";
             }
-            hunks.push(new Hunk(srcStart, srcLines, dstStart, dstLines));
-            srcStart = srcStart + srcLines.length;
-            srcLines = new Array();
-            dstStart = dstStart + dstLines.length;
-            dstLines = new Array();
-        } else if (line.startsWith(' ') && isBefore) {
-            srcStart++;
-            dstStart++;
-        } else if (line.startsWith('-')) {
-            isBefore = false;
-            srcLines.push(line);
-
-        } else if (line.startsWith('+')) {
-            isBefore = false;
-            dstLines.push(line);
-        } else if (line.startsWith("\\ No newline at end of file")) {
-            continue;
-        } else if (line === "") {
-            continue;
-        } else {
-            throw "Unexpected content on line " + i + ": '" + line + "'";
         }
-    }
 
-    // The last hunk did not have context after
-    if (srcLines.length > 0 || dstLines.length > 0) {
-        hunks.push(new Hunk(srcStart, srcLines, dstStart, dstLines));
+        // The last hunk did not have context after
+        if (srcLines.length > 0 || dstLines.length > 0) {
+            hunks.push(new Hunk(srcStart, srcLines, dstStart, dstLines));
+        }
     }
 
     return hunks;
@@ -1677,10 +1705,14 @@ async function init() {
 
     // Pre-fetch base and head content for up to 25 files
     for (let i = 0; i < Math.min(files.length, 25); i++) {
-        state.index = i;
-        const content = fetchFileContent(state);
-        state.head.content[i] = content.head;
-        state.base.content[i] = content.base;
+        if (state.comparison.files[i].binary === false) {
+            state.index = i;
+            const content = fetchFileContent(state);
+            if (content != null) {
+                state.head.content[i] = content.head;
+                state.base.content[i] = content.base;
+            }
+        }
     }
     state.index = -1;
 }

--- a/index.html
+++ b/index.html
@@ -227,7 +227,7 @@ function render(state) {
     body().removeEventListener("keydown", framesOnKeyDown);
     body().style.margin = 0;
     if (state.view !== "index") {
-        if (state.comparison.files[state.index].binary === false) {
+        if (!state.comparison.files[state.index].binary) {
             if (state.head.content[state.index] === null || state.base.content[state.index] === null) {
                 const content = fetchFileContent(state);
                 if (content != null) {
@@ -406,7 +406,7 @@ async function renderIndex(state) {
         const p = create("p");
         const code = create("code");
         if (file.status === "modified" || file.status === "copied" || file.status === "renamed") {
-            if (file.binary === true) {
+            if (file.binary) {
                 code.append("------ ");
                 code.append("------ ");
                 code.append("------ ");
@@ -475,7 +475,7 @@ async function renderIndex(state) {
             code.append("------ ");
             code.append("--- ");
 
-            if (file.binary === true) {
+            if (file.binary) {
                 code.append("--- ");
                 code.append("----- ");
             } else {
@@ -508,7 +508,7 @@ async function renderIndex(state) {
             code.append("------ ");
             code.append("------ ");
 
-            if (file.binary === true) {
+            if (file.binary) {
                 code.append("--- ");
                 code.append("--- ");
                 code.append("----- ");
@@ -1503,59 +1503,61 @@ function addContext(hunks, n, baseContent, headContent) {
 
 function removeContext(patch) {
     const hunks = new Array();
-    if (patch != null) {
-        let srcStart = 0;
-        let srcLines = new Array();
-        let dstStart = 0;
-        let dstLines = new Array();
-        let isBefore = true;
+    if (patch === null) {
+        return hunks
+    }
 
-        const lines = patch.split('\n');
-        const end = patch.endsWith('\n') ? lines.length - 1 : lines.length;
-        for (let i = 0; i < end; i++) {
-            const line = lines[i];
-            if (line.startsWith("@@")) {
-                if (srcLines.length > 0 || dstLines.length > 0) {
-                    hunks.push(new Hunk(srcStart, srcLines, dstStart, dstLines));
-                }
+    let srcStart = 0;
+    let srcLines = new Array();
+    let dstStart = 0;
+    let dstLines = new Array();
+    let isBefore = true;
 
-                const parts = line.split(' ');
-                srcStart = Number(parseRange(parts[1]).start);
-                dstStart = Number(parseRange(parts[2]).start);
-                srcLines = new Array();
-                dstLines = new Array();
-            } else if (line.startsWith(' ') && !isBefore) {
-                while (i < lines.length && lines[i].startsWith(' ')) {
-                    i++;
-                }
+    const lines = patch.split('\n');
+    const end = patch.endsWith('\n') ? lines.length - 1 : lines.length;
+    for (let i = 0; i < end; i++) {
+        const line = lines[i];
+        if (line.startsWith("@@")) {
+            if (srcLines.length > 0 || dstLines.length > 0) {
                 hunks.push(new Hunk(srcStart, srcLines, dstStart, dstLines));
-                srcStart = srcStart + srcLines.length;
-                srcLines = new Array();
-                dstStart = dstStart + dstLines.length;
-                dstLines = new Array();
-            } else if (line.startsWith(' ') && isBefore) {
-                srcStart++;
-                dstStart++;
-            } else if (line.startsWith('-')) {
-                isBefore = false;
-                srcLines.push(line);
-
-            } else if (line.startsWith('+')) {
-                isBefore = false;
-                dstLines.push(line);
-            } else if (line.startsWith("\\ No newline at end of file")) {
-                continue;
-            } else if (line === "") {
-                continue;
-            } else {
-                throw "Unexpected content on line " + i + ": '" + line + "'";
             }
-        }
 
-        // The last hunk did not have context after
-        if (srcLines.length > 0 || dstLines.length > 0) {
+            const parts = line.split(' ');
+            srcStart = Number(parseRange(parts[1]).start);
+            dstStart = Number(parseRange(parts[2]).start);
+            srcLines = new Array();
+            dstLines = new Array();
+        } else if (line.startsWith(' ') && !isBefore) {
+            while (i < lines.length && lines[i].startsWith(' ')) {
+                i++;
+            }
             hunks.push(new Hunk(srcStart, srcLines, dstStart, dstLines));
+            srcStart = srcStart + srcLines.length;
+            srcLines = new Array();
+            dstStart = dstStart + dstLines.length;
+            dstLines = new Array();
+        } else if (line.startsWith(' ') && isBefore) {
+            srcStart++;
+            dstStart++;
+        } else if (line.startsWith('-')) {
+            isBefore = false;
+            srcLines.push(line);
+
+        } else if (line.startsWith('+')) {
+            isBefore = false;
+            dstLines.push(line);
+        } else if (line.startsWith("\\ No newline at end of file")) {
+            continue;
+        } else if (line === "") {
+            continue;
+        } else {
+            throw "Unexpected content on line " + i + ": '" + line + "'";
         }
+    }
+
+    // The last hunk did not have context after
+    if (srcLines.length > 0 || dstLines.length > 0) {
+        hunks.push(new Hunk(srcStart, srcLines, dstStart, dstLines));
     }
 
     return hunks;
@@ -1705,7 +1707,7 @@ async function init() {
 
     // Pre-fetch base and head content for up to 25 files
     for (let i = 0; i < Math.min(files.length, 25); i++) {
-        if (state.comparison.files[i].binary === false) {
+        if (!state.comparison.files[i].binary) {
             state.index = i;
             const content = fetchFileContent(state);
             if (content != null) {


### PR DESCRIPTION
Please review this fix, which fixes handling of binary files in webrev diffs. We should not even attempt to show diffs for binary files.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [SKARA-1015](https://bugs.openjdk.java.net/browse/SKARA-1015): Webrev can't handle changes with binary files


### Reviewers
 * [Erik Helin](https://openjdk.java.net/census#ehelin) (@edvbld - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/cr pull/16/head:pull/16` \
`$ git checkout pull/16`

Update a local copy of the PR: \
`$ git checkout pull/16` \
`$ git pull https://git.openjdk.java.net/cr pull/16/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16`

View PR using the GUI difftool: \
`$ git pr show -t 16`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/cr/pull/16.diff">https://git.openjdk.java.net/cr/pull/16.diff</a>

</details>
